### PR TITLE
107 auto stale locks cleanup doesnt work with restic 0.9.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,22 +3,22 @@
 files: \.(py|yaml|yml)$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: "5.0.4"
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/enacrestic/restic_backup.py
+++ b/enacrestic/restic_backup.py
@@ -208,9 +208,7 @@ class ResticBackup:
                     ResticCompletionStatus.REPO_NOT_INITIALIZED
                 )
 
-            elif re.search(
-                r"the `unlock` command can be used to remove stale locks", stderr
-            ):
+            elif re.search(r"unable to create lock in backend", stderr):
                 self.current_process_completion_status = (
                     ResticCompletionStatus.REPO_LOCKED
                 )


### PR DESCRIPTION
restic _0.9.6_ gives the following output:

! Fatal: unable to create lock in backend: repository is already locked by PID 149125 on dell-2014 by bancal (UID 1000, GID 1000)
! lock was created at 2023-04-02 15:26:23 (3545h35m48.046863146s ago)
! storage ID b24247ff
! 

and restic _0.12.1_ gives the following output:

! unable to create lock in backend: repository is already locked by PID 45743 on dell2020 by sbancal (UID 1000, GID 1000)
! lock was created at 2023-09-11 18:21:09 (44h50m42.007266376s ago)
! storage ID 1e5ac5fb
! the `unlock` command can be used to remove stale locks
! 

Simply look for the right sentence 